### PR TITLE
ensure print uses parenthesis for print calls

### DIFF
--- a/pixiedust_node/npm.py
+++ b/pixiedust_node/npm.py
@@ -25,7 +25,7 @@ class Npm:
                 args.append(module)
             else:
                 args.extend(module)
-        print ' '.join(args)
+        print (' '.join(args))
         ps = subprocess.Popen( args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd = node_home)
         
         # create thread to read this process's output          

--- a/pixiedust_node/package.json
+++ b/pixiedust_node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pixiedust_node",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Run Node.js cells in Jupyter notebooks with Pixiedust",
   "main": "pixiedustNodeRepl.js",
   "scripts": {

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='pixiedust_node',
-      version='0.1.3',
+      version='0.1.4',
       description='Pixiedust extension for Node.js',
       url='https://github.com/ibm-watson-data-lab/pixiedust_node',
       install_requires=['pixiedust'],


### PR DESCRIPTION
quick release to ensure calls to `print` have brackets, for Python 3 compatibility. Hat tip to @ajalger 