### PR TITLE
allow Node.js to die gracefully

### DIFF
--- a/pixiedust_node/pixiedustNodeRepl.js
+++ b/pixiedust_node/pixiedustNodeRepl.js
@@ -29,6 +29,7 @@ const startRepl = function(instream, outstream) {
 
   // sync Node.js to Python every 1 second
   interval = setInterval(globalVariableChecker, 1000);
+  interval.unref();
 
   // custom writer function that outputs nothing
   const writer = function(output) {


### PR DESCRIPTION
As the Node.js variable migration logic uses a `setInterval` we need to "unref" it to allow the Node.js process to die when the REPL is killed