### PR TITLE
prevent python-->node variable migration using Node.js reserved words -issue #22

### DIFF
--- a/pixiedust_node/node.py
+++ b/pixiedust_node/node.py
@@ -13,6 +13,8 @@ from pixiedust.display import display
 from pixiedust.utils.environment import Environment
 from pixiedust.utils.shellAccess import ShellAccess
 
+RESERVED = ['true', 'false','self','this','In','Out']
+
 try:
     VARIABLE_TYPES = (str, int, float, bool, unicode, dict, list)
 except:
@@ -40,7 +42,7 @@ class VarWatcher(object):
             v = self.shell.user_ns[key]
             t = type(v)
             # if this is one of our varables, is a number or a string or a float
-            if not key.startswith('_') and (t in VARIABLE_TYPES):
+            if not key.startswith('_') and (not key in RESERVED) and (t in VARIABLE_TYPES):
                 # if it's not in our cache or it is an its value has changed
                 if not key in self.cache or (key in self.cache and self.cache[key] != v):
                     # move it to JavaScript land and add it to our cache


### PR DESCRIPTION
Running `display` in a Python cell caused some global variables to be set which pixiedust_node tried to migrate to the Node.js environment. These included `true`, `false` and `self`.  Doing:

```js
> var true = true
... 
``` 

in a Node.js repl causes it to hang. 

I fixed this by creating a list of variable names that won't ever be migrate from Python --> Node.