### PR TITLE
terminate Node.js process on Kernel shutdown - fixes issue #23

### DIFF
--- a/pixiedust_node/node.py
+++ b/pixiedust_node/node.py
@@ -197,13 +197,16 @@ class Node(NodeBase):
         # process that runs the Node.js code
         args = (self.node_path, path)
         self.ps = self.popen(args)
-        # print ("Node process id", self.ps.pid)
+        print ("Node process id", self.ps.pid)
 
         # create thread to read this process's output
         NodeStdReader(self.ps)
 
         # watch Python variables for changes
         self.vw = VarWatcher(get_ipython(), self.ps)
+
+    def terminate(self):
+        self.ps.terminate()
 
     def write(self, s):
         self.ps.stdin.write(s)


### PR DESCRIPTION
- Listen for iPython `shutdown_hook` 
- when it arrives, kill the Node.js process