### PR TITLE
ensure node->python variable messages are dicts - fixes issue #27

### DIFF
--- a/pixiedust_node/node.py
+++ b/pixiedust_node/node.py
@@ -88,7 +88,7 @@ class NodeStdReader(Thread):
 
             try:
                 # if it does and is a pixiedust object
-                if obj and obj['_pixiedust']:
+                if obj and isinstance(obj, dict) and obj['_pixiedust']:
                     if obj['type'] == 'display':
                         pdf = pandas.DataFrame(obj['data'])
                         ShellAccess.pdf = pdf


### PR DESCRIPTION
Make sure that just because a message from node->Python parses as JSON, we don't assume it's a dict/object