### PR TITLE
try: unicode except NameError: to silence linters

### DIFF
--- a/pixiedust_node/node.py
+++ b/pixiedust_node/node.py
@@ -211,6 +211,7 @@ class Node(NodeBase):
         #print ("Node process id", self.ps.pid)
 
         # watch Python variables for changes
+        global get_ipython  # placates linters like PyLint and Flake8
         self.vw = VarWatcher(get_ipython(), self.ps)
 
         # create thread to read this process's output

--- a/pixiedust_node/node.py
+++ b/pixiedust_node/node.py
@@ -18,7 +18,7 @@ RESERVED = ['true', 'false','self','this','In','Out']
 
 try:
     VARIABLE_TYPES = (str, int, float, bool, unicode, dict, list)
-except:
+except NameError:
     # Python 3 => no unicode type
     VARIABLE_TYPES = (str, int, float, bool, dict, list)
 


### PR DESCRIPTION
Linters like PyLint and Flake8 will complain in the absence of the specific exception.