### PR TITLE
move pixiedust to its own GitHub org

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The `pixiedust_node` Python module has access to Pixiedust's *display* API to re
 
 ## Prerequisites
 
-To use `pixiedust_node` you need to be running a Jupyter notebooks with the [Pixedust](https://github.com/ibm-cds-labs/pixiedust) extension installed. Notebooks can be run locally by [installing Pixiedust and its prerequisites](https://ibm-watson-data-lab.github.io/pixiedust/install.html).
+To use `pixiedust_node` you need to be running a Jupyter notebooks with the [Pixedust](https://github.com/pixiedust/pixiedust) extension installed. Notebooks can be run locally by [installing Pixiedust and its prerequisites](https://pixiedust.github.io/pixiedust/install.html).
 
 
 You also need Node.js/npm installed. See the [Node.js downloads](https://nodejs.org/en/download/) page to find an installer for your platform.

--- a/pixiedust_node/__init__.py
+++ b/pixiedust_node/__init__.py
@@ -31,8 +31,8 @@ class PixiedustNodeMagics(Magics):
         display(HTML(
 """
             <div style="margin:10px"> 
-            <a href="https://github.com/ibm-cds-labs/pixiedust_node" target="_new"> 
-            <img src="https://github.com/ibm-cds-labs/pixiedust_node/raw/master/docs/_images/pdn_icon32.png" style="float:left;margin-right:10px"/> 
+            <a href="https://github.com/pixiedust/pixiedust_node" target="_new"> 
+            <img src="https://github.com/pixiedust/pixiedust_node/raw/master/docs/_images/pdn_icon32.png" style="float:left;margin-right:10px"/> 
             </a> 
             <span>Pixiedust Node.js</span> 
             </div> 

--- a/pixiedust_node/package.json
+++ b/pixiedust_node/package.json
@@ -16,6 +16,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/ibm-cds-labs/pixiedust_node"
+    "url": "https://github.com/pixiedust/pixiedust_node"
   }
 }

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(name='pixiedust_node',
       version='0.2.5',
       description='Pixiedust extension for Node.js',
-      url='https://github.com/ibm-watson-data-lab/pixiedust_node',
+      url='https://github.com/pixiedust/pixiedust_node',
       install_requires=['pixiedust', 'pandas', 'ipython'],
       package_data={
         '': ['*.js','*.json']


### PR DESCRIPTION
Changed references to old GitHub organisations to the new "pixiedust" GitHub organisation